### PR TITLE
Feature/delete saved posters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -222,10 +222,9 @@ function savePoster() {
       // if (currentPoster.id !== savedPosters[0].id) {
       var arrayCheck = savedPosters.find(object => object.id === currentPoster.id);
       if (arrayCheck === undefined) {
-        console.log('arrayCheck result: ', arrayCheck)
         savedPosters.push(currentPoster);
         savedPostersGrid.insertAdjacentHTML('afterbegin', `
-          <div class="mini-poster">
+          <div class="mini-poster" id=${currentPoster.id}>
             <img src="${currentPoster.imageURL}" alt="motivational poster image">
             <h2>${currentPoster.title}</h2>
             <h4>${currentPoster.quote}</h4>
@@ -234,5 +233,55 @@ function savePoster() {
       };
 // }
 };
+
+
+
+
+// create a function that will
+//1. declare a variable that stores the id of the selected poster
+// (var selectedPosterId = ???)
+// Q: how to access an element id with an event (double click)
+// event.target??
+//2. declare a variable to access the clicked element by id
+// (var selectedPoster = document.getElementById(selectedPosterId))
+//3. add the .delete or the .hidden class to the selectedPoster variable
+// (selectedPoster.classList.add(delete)???)
+// NOTE: adding the .hidden class removes the poster from the page
+//4. remove the selected poster from the savedPosters array by ID number
+//
+//for loop?
+// for(var i = 0; i < savedPosters.length; i++) {
+//if(savedPosters[i].id === selectedPosterId) {
+ //savedPosters.splice(i, 1);
+//create an event listener that will wait for a double click and execute deletePoster function
+
+
+
+function getID(e) {
+  if(e.target.hasAttribute('id'))
+  var idValue = e.target.getAttribute('id')
+
+  console.log('ID HERE:', idValue)
+
+  var selectedPoster = document.getElementById(`${idValue}`)
+  console.log('selectedPoster:', selectedPoster)
+  selectedPoster.classList.add('hidden')
+}
+
+// var buttonGroupPressed = e => { 
+//   if (e.target.hasAttribute('id'))
+
   
-//pseudcode here:
+//   if(!isButton) {
+//     return
+//   }
+  
+//   console.log(e.target.id);
+  
+// }
+// buttonGroup.addEventListener("click", buttonGroupPressed);
+
+
+
+
+savedPostersGrid.addEventListener('click', getID)

--- a/src/main.js
+++ b/src/main.js
@@ -235,4 +235,4 @@ function savePoster() {
 // }
 };
   
-      
+//pseudcode here:

--- a/src/main.js
+++ b/src/main.js
@@ -266,8 +266,13 @@ function getID(e) {
   var selectedPoster = document.getElementById(`${idValue}`)
   console.log('selectedPoster:', selectedPoster)
   selectedPoster.classList.add('hidden')
-}
 
+  for (var i = 0; i < savedPosters.length; i++) {
+    if (savedPosters[i].id == idValue) {
+    savedPosters.splice(i, 1)
+  }
+}
+}
 // var buttonGroupPressed = e => { 
 //   if (e.target.hasAttribute('id'))
 
@@ -284,4 +289,4 @@ function getID(e) {
 
 
 
-savedPostersGrid.addEventListener('click', getID)
+savedPostersGrid.addEventListener('dblclick', getID)

--- a/src/main.js
+++ b/src/main.js
@@ -128,8 +128,9 @@ makeYourOwnPosterButton.addEventListener('click', switchToForm);
 showSavedPostersButton.addEventListener('click', switchToSavedPosters);
 backToMainButton.addEventListener('click', switchToMain);
 takeMeBackButton.addEventListener('click', switchToMain);
-showMyPosterButton.addEventListener('click', handleAllEvents);
+showMyPosterButton.addEventListener('click', showMyPoster);
 saveThisPosterButton.addEventListener('click', savePoster);
+savedPostersGrid.addEventListener('dblclick', deletePoster)
 
 
 // functions and event handlers go here 👇
@@ -166,7 +167,7 @@ function pushToArrays() {
   quotes.push(currentPoster.quote)
 };
 
-function handleAllEvents() {
+function showMyPoster() {
   newPosterObject();
   switchToMain();
   event.preventDefault();
@@ -182,9 +183,7 @@ function makeRandomPoster() {
   posterTitle.innerHTML = randomTitle;
   posterImage.src = randomImage;
   currentPoster = createPoster(randomImage, randomTitle, randomQuote);
-  // console.log('currentPoster: ', currentPoster)
 };
-
 
 makeRandomPoster();
 
@@ -206,87 +205,30 @@ function switchToMain() {
   savedPostersSection.classList.add('hidden');
 };
 
-// savedPostersGrid.innerHTML = `
-//   <div class="mini-poster saved-posters-grid"> </div>
-//   `;
-  
-// var miniPosters = document.querySelector('.mini-poster');
-
-
 function savePoster() {
-  // savedPosters.forEach((object) => if (currentPoster.id !== object.id) {  
-  // savedPosters.push(currentPoster)});
-    // for (var i = -1; i < savedPosters.length; i++) {
-    //  var savedPosterCheck = savedPosters.find((object) => object.id === currentPoster.id)
-    //  if (savedPosterCheck = undefined) { 
-      // if (currentPoster.id !== savedPosters[0].id) {
-      var arrayCheck = savedPosters.find(object => object.id === currentPoster.id);
-      if (arrayCheck === undefined) {
-        savedPosters.push(currentPoster);
-        savedPostersGrid.insertAdjacentHTML('afterbegin', `
-          <div class="mini-poster" id=${currentPoster.id}>
-            <img src="${currentPoster.imageURL}" alt="motivational poster image">
-            <h2>${currentPoster.title}</h2>
-            <h4>${currentPoster.quote}</h4>
-          </div>
-          `)
-      };
-// }
+  var arrayCheck = savedPosters.find(object => object.id === currentPoster.id);
+  if (arrayCheck === undefined) {
+    savedPosters.push(currentPoster);
+    savedPostersGrid.insertAdjacentHTML(
+      'afterbegin', `
+      <div class="mini-poster" id=${currentPoster.id}>
+        <img src="${currentPoster.imageURL}" alt="motivational poster image">
+        <h2>${currentPoster.title}</h2>
+        <h4>${currentPoster.quote}</h4>
+      </div>
+    `)
+  };
 };
 
-
-
-
-// create a function that will
-//1. declare a variable that stores the id of the selected poster
-// (var selectedPosterId = ???)
-// Q: how to access an element id with an event (double click)
-// event.target??
-//2. declare a variable to access the clicked element by id
-// (var selectedPoster = document.getElementById(selectedPosterId))
-//3. add the .delete or the .hidden class to the selectedPoster variable
-// (selectedPoster.classList.add(delete)???)
-// NOTE: adding the .hidden class removes the poster from the page
-//4. remove the selected poster from the savedPosters array by ID number
-//
-//for loop?
-// for(var i = 0; i < savedPosters.length; i++) {
-//if(savedPosters[i].id === selectedPosterId) {
- //savedPosters.splice(i, 1);
-//create an event listener that will wait for a double click and execute deletePoster function
-
-
-
-function getID(e) {
+function deletePoster(e) {
   if(e.target.hasAttribute('id'))
-  var idValue = e.target.getAttribute('id')
-
-  console.log('ID HERE:', idValue)
-
-  var selectedPoster = document.getElementById(`${idValue}`)
-  console.log('selectedPoster:', selectedPoster)
-  selectedPoster.classList.add('hidden')
-
+    var idValue = e.target.getAttribute('id')
+    var selectedPoster = document.getElementById(`${idValue}`)
+    selectedPoster.classList.add('hidden')
   for (var i = 0; i < savedPosters.length; i++) {
     if (savedPosters[i].id == idValue) {
-    savedPosters.splice(i, 1)
+      savedPosters.splice(i, 1)
+    }
   }
 }
-}
-// var buttonGroupPressed = e => { 
-//   if (e.target.hasAttribute('id'))
 
-  
-//   if(!isButton) {
-//     return
-//   }
-  
-//   console.log(e.target.id);
-  
-// }
-// buttonGroup.addEventListener("click", buttonGroupPressed);
-
-
-
-
-savedPostersGrid.addEventListener('dblclick', getID)

--- a/src/main.js
+++ b/src/main.js
@@ -206,11 +206,11 @@ function switchToMain() {
   savedPostersSection.classList.add('hidden');
 };
 
-savedPostersGrid.innerHTML = `
-  <div class="mini-poster saved-posters-grid"> </div>
-  `;
+// savedPostersGrid.innerHTML = `
+//   <div class="mini-poster saved-posters-grid"> </div>
+//   `;
   
-var miniPosters = document.querySelector('.mini-poster');
+// var miniPosters = document.querySelector('.mini-poster');
 
 
 function savePoster() {
@@ -224,7 +224,7 @@ function savePoster() {
       if (arrayCheck === undefined) {
         console.log('arrayCheck result: ', arrayCheck)
         savedPosters.push(currentPoster);
-        miniPosters.insertAdjacentHTML('afterbegin', `
+        savedPostersGrid.insertAdjacentHTML('afterbegin', `
           <div class="mini-poster">
             <img src="${currentPoster.imageURL}" alt="motivational poster image">
             <h2>${currentPoster.title}</h2>


### PR DESCRIPTION
Summary - Added feature to delete saved posters with a double click from the saved posters section and the saved posters array.

Code Notes/Questions - Had to use getElementById to interpolate the idValue. Is there a correct way to format this if using querySelector?

What to look for? - Our double click to grab element ID is only recognized around the border of the image. If the click occurs in the middle of the image, the ID is not grabbed and the poster is not then deleted. In the screenshot provided, the green area is to be double clicked to grab the element ID.
![Screenshot 2023-12-09 at 8 49 27 PM](https://github.com/tednaphil/hang-in-there-tory/assets/41808895/f388cd63-5d34-4cb1-9e15-ffd2eeb3b782)
